### PR TITLE
Fixes logic error leading to unuseful error

### DIFF
--- a/crates/zlib-searcher-core/src/lib.rs
+++ b/crates/zlib-searcher-core/src/lib.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DefaultOnError, DefaultOnNull};
-use tantivy::{schema::*, store::Compressor, Index};
+use tantivy::{schema::*, store::Compressor, Index, TantivyError};
 use tokenizer::{get_tokenizer, META_DATA_TOKENIZER};
 
 pub mod index;
@@ -115,9 +115,13 @@ impl Searcher {
 
         // open or create index
         let index_dir = index_dir.as_ref();
-        let mut index = Index::open_in_dir(index_dir).unwrap_or_else(|_| {
-            std::fs::create_dir_all(index_dir).expect("create index directory");
-            Index::create_in_dir(index_dir, schema.clone()).unwrap()
+        let mut index = Index::open_in_dir(index_dir).unwrap_or_else(|err| {
+            if let TantivyError::OpenDirectoryError(_) = err {
+                std::fs::create_dir_all(index_dir).expect("create index directory");
+                Index::create_in_dir(index_dir, schema.clone()).unwrap()
+            } else {
+                panic!("Error opening index: {err:?}")
+            }
         });
         #[cfg(feature = "best-size")]
         {

--- a/crates/zlib-searcher-core/src/lib.rs
+++ b/crates/zlib-searcher-core/src/lib.rs
@@ -116,7 +116,7 @@ impl Searcher {
         // open or create index
         let index_dir = index_dir.as_ref();
         let mut index = Index::open_in_dir(index_dir).unwrap_or_else(|err| {
-            if let TantivyError::OpenDirectoryError(_) = err {
+            if let TantivyError::OpenDirectoryError(_) | TantivyError::OpenReadError(_) = err {
                 std::fs::create_dir_all(index_dir).expect("create index directory");
                 Index::create_in_dir(index_dir, schema.clone()).unwrap()
             } else {


### PR DESCRIPTION
When opening/creating an Index, the code currently assumes that `Index::open_in_dir` only returns errors for `meta.json` not existing, when that is not the case. This can lead to the code trying to create a new index when there already is one present.

This commit just makes it give a more informative panic in the case that it gives a different error.

See issue #54 for more information.